### PR TITLE
fix handling of empty text editing events

### DIFF
--- a/src/PharoIM-Core/RubAbstractTextArea.extension.st
+++ b/src/PharoIM-Core/RubAbstractTextArea.extension.st
@@ -91,8 +91,11 @@ RubAbstractTextArea >> keyboardFocusChange: aBoolean [
 { #category : #'*PharoIM-Core' }
 RubAbstractTextArea >> textEdition: aTextEditionEvent [
 
-	self editor zapSelectionWith: aTextEditionEvent text.
-	editing := true
+	aTextEditionEvent text
+		ifNotEmpty: [ :editText | 
+			self editor zapSelectionWith: editText.
+			editing := true ]
+		ifEmpty: [ editing := false ]
 ]
 
 { #category : #'*PharoIM-Core' }


### PR DESCRIPTION
This happens when moving cursors with IM turned on.
Fixes https://github.com/tomooda/PharoIM/issues/3